### PR TITLE
Bash script for service file management

### DIFF
--- a/manage_services.bash
+++ b/manage_services.bash
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+allowed_platforms=("freddy")
+allowed_cmds=("enable","restart","disable")
+platform=$1
+cmd=$2
+
+if [[ -z "$platform" ]] || [[ ${allowed_platforms[*]} != $platform ]]; then
+    echo "Manages all service files for a specified platform"
+    echo "Usage: ./manage_services.bash [platform] [cmd]"
+    echo "       where the allowed values for platform are [$allowed_platforms]"
+    echo "       and the allowed values for cmd are [$allowed_cmds]"
+    exit 1
+else
+    if [ $cmd == "enable" ]; then
+        echo 'Copying service files to /etc/systemd/system...';
+        sudo cp $platform/* /etc/systemd/system/
+        echo 'Service files copied successfully';
+
+        echo 'Enabling services...';
+        service_files=$(ls $platform);
+        for service in $service_files; do
+            echo 'Enabling' $service;
+            sudo systemctl enable $service
+        done
+        echo 'Services enabled successfully';
+    elif [ $cmd == "restart" ]; then
+        echo 'Restarting services...';
+        service_files=$(ls $platform);
+        for service in $service_files; do
+            echo 'Restarting' $service;
+            sudo systemctl restart $service
+        done
+        echo 'All services have been restarted';
+    elif [ $cmd == "disable" ]; then
+        echo 'Disabling services...';
+        service_files=$(ls $platform);
+        for service in $service_files; do
+            echo 'Disabling' $service;
+            sudo systemctl disable $service
+
+            echo 'Removing' $service 'from /etc/systemd/system';
+            sudo rm /etc/systemd/system/$service
+        done
+        echo 'Services disabled';
+    else
+        echo "Unknown command $cmd"
+    fi
+fi


### PR DESCRIPTION
### Short Description

This PR adds a bash script `manage_services.bash`, which can be used to manage the service files for a given robot platform. `manage_services.bash` is based on the setup scripts in https://github.com/ropod-project/automatic-startup, but combines these into a single script for convenience.

### Usage

The general usage is
```
./manage_services.bash [platform] [cmd]
```

The script is invoked with two arguments:
1. `platform`: Name of a platform for which a directory with service files exists (currently only `freddy` is allowed)
2. `cmd`: Command to perform on the services. The possible values are:
    * `enable`: Copies the service files to `/etc/systemd/system` and enables the services
    * `disable`: Disables the services and removes the service files from `/etc/systemd/system`
    * `restart`: Restarts all services

An example call for enabling the services for the robot `freddy` would be
```
./manage_services.bash freddy enable
```